### PR TITLE
Add User-Agent header to Canvas API HTTP clients

### DIFF
--- a/src/CanvasKpiLti/Program.cs
+++ b/src/CanvasKpiLti/Program.cs
@@ -156,6 +156,7 @@ public class Program
         {
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            client.DefaultRequestHeaders.Add("User-Agent", "CanvasKpi");
             client.BaseAddress = new Uri(_configuration["CanvasApi:baseUrl"] + "/api/graphql");
         });
 
@@ -163,6 +164,7 @@ public class Program
         {
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            client.DefaultRequestHeaders.Add("User-Agent", "CanvasKpi");
             client.BaseAddress = new Uri(_configuration["CanvasApi:baseUrl"]!);
         });
 


### PR DESCRIPTION
Fixes #9

Adds `User-Agent` header with value `CanvasKpi` to Canvas API HTTP clients.

Canvas API requires User-Agent header and returns "Not Authorized" error without it.

## Changes
- Added User-Agent header to CanvasGraphQlHttpClient configuration
- Added User-Agent header to CanvasRestHttpClient configuration  
- Fixed TokenStore to use IHttpClientFactory instead of `new HttpClient()`
- TokenStore now adds User-Agent to OAuth token refresh requests

## Root Cause
TokenStore was creating HttpClient directly, bypassing factory configuration and missing User-Agent. This caused token refresh failures on requests like `/AssignmentRubric/index`.