### PR TITLE
Fix missing User-Agent in OAuth token refresh

### DIFF
--- a/src/CanvasKpiLti/Services/TokenStore.cs
+++ b/src/CanvasKpiLti/Services/TokenStore.cs
@@ -15,6 +15,7 @@ public class TokenStore
 {
     private readonly IConfiguration _configuration;
     private readonly HttpContext _httpContext;
+    private readonly IHttpClientFactory _httpClientFactory;
 
     private string? _token;
     public string? Token {
@@ -30,10 +31,11 @@ public class TokenStore
     private DateTime ExpiresAt { get; set; }
 
 
-    public TokenStore(IHttpContextAccessor httpContextAccessor,IConfiguration configuration)
+    public TokenStore(IHttpContextAccessor httpContextAccessor, IConfiguration configuration, IHttpClientFactory httpClientFactory)
     {
         _configuration = configuration;
         _httpContext = httpContextAccessor.HttpContext ?? throw new Exception("httpContext is null");
+        _httpClientFactory = httpClientFactory;
         
         Debug.WriteLine("GetToken from httpContextAccessor");
         _token = _httpContext.GetTokenAsync("token", "access_token").Result;
@@ -80,7 +82,8 @@ public class TokenStore
             new ("refresh_token", refreshToken)
         };
         var queryString = new FormUrlEncodedContent(pairs);
-        using var client = new HttpClient();
+        using var client = _httpClientFactory.CreateClient();
+        client.DefaultRequestHeaders.Add("User-Agent", "CanvasKpi");
         var response =  client.PostAsync(oauthTokenUrl, queryString).Result;
 
         if (response.IsSuccessStatusCode)


### PR DESCRIPTION
Fixes #9

TokenStore was creating `new HttpClient()` directly, bypassing IHttpClientFactory and missing User-Agent header. This caused OAuth token refresh requests to fail with "Not Authorized" error.

## Changes
- Inject IHttpClientFactory into TokenStore constructor
- Use factory to create HttpClient with User-Agent header for token refresh

## Root Cause
Line 83 in TokenStore.cs created HttpClient directly instead of using factory, missing the User-Agent configuration from Program.cs. Canvas API requires User-Agent header on all requests including OAuth token endpoint.

## Related
- Follows up on merged PR #8 which added User-Agent to main API clients
- Completes fix for issue #9